### PR TITLE
feat(bots): add first-class bot use-case listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,27 @@ Auto-detected components:
 
 See the [Open Plugins specification](https://open-plugins.com/plugin-builders/specification) and [plugin template](https://github.com/cursor/plugin-template) for details.
 
+### Submit a Bot
+
+A bot listing is a use-case page, not a plugin. It is a copyable template, the plugins and skills that template needs, and a writeup that can rank in search. It is not an Open Plugins `agents/*.md` file. Submit those as plugins.
+
+1. Go to [cursor.directory/bots/new](https://cursor.directory/bots/new)
+2. Sign in with GitHub or Google
+3. Paste a GitHub repo URL, or fill in the template and writeup by hand
+4. Click **Submit**
+
+The listing stays unpublished until an admin reviews it at `/admin/bots`. Security scan is not wired for bots yet. Plugin submit, scan, and trending are unchanged.
+
+Auto-detected bot files:
+
+| File | What we read |
+|------|----------------|
+| `bot.json` or `.cursor/bot.json` | `name`, `description`, `template`, `writeup`, `plugins`, `skills` |
+| `BOT.md` or `template.md` | Copyable template if JSON omits `template` |
+| `WRITEUP.md` or `README.md` | Use-case writeup if JSON omits `writeup` |
+
+If the repo only contains `agents/*.md` (and no bot manifest), the submit form tells you to use [plugin submit](https://cursor.directory/plugins/new) instead. `parseGitHubPlugin` cannot serve this flow: it requires Open Plugins components and treats `agents/*.md` as plugin body, so a bot-only repo fails with `no_components`.
+
 ---
 
 ## Tech Stack

--- a/apps/cursor/src/actions/create-bot.ts
+++ b/apps/cursor/src/actions/create-bot.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { z } from "zod";
+import { InsertBotError, insertBot } from "@/lib/bots/insert";
+import { botNeedSchema } from "@/lib/bots/types";
+import { resolveGithubRepoIdFromRepository } from "@/lib/github-plugin/parse";
+import { pluginScanLimit } from "@/lib/rate-limit";
+import { ActionError, authActionClient } from "./safe-action";
+
+export const createBotAction = authActionClient
+  .metadata({
+    actionName: "create-bot",
+  })
+  .schema(
+    z.object({
+      name: z.string().min(2, "Name must be at least 2 characters"),
+      description: z
+        .string()
+        .min(10, "Description must be at least 10 characters"),
+      writeup: z.string().min(40, "Writeup must be at least 40 characters"),
+      template: z.string().min(20, "Template must be at least 20 characters"),
+      needs: z.array(botNeedSchema).optional(),
+      repository: z.string().url().nullable().optional(),
+      homepage: z.string().url().nullable().optional(),
+    }),
+  )
+  .action(
+    async ({
+      parsedInput: {
+        name,
+        description,
+        writeup,
+        template,
+        needs,
+        repository,
+        homepage,
+      },
+      ctx: { userId },
+    }) => {
+      const { success } = await pluginScanLimit(userId);
+      if (!success) {
+        throw new ActionError(
+          "Too many submissions in the last hour. Please try again later.",
+        );
+      }
+
+      const githubRepoId = await resolveGithubRepoIdFromRepository(repository, {
+        maxWaitMs: 3000,
+      });
+
+      let result: { id: string; slug: string };
+      try {
+        result = await insertBot(
+          {
+            name,
+            description,
+            writeup,
+            template,
+            needs,
+            repository,
+            homepage,
+          },
+          {
+            ownerId: userId,
+            source: "user",
+            skipReview: false,
+            githubRepoId,
+          },
+        );
+      } catch (err) {
+        if (err instanceof InsertBotError) {
+          if (err.code === "duplicate_name" || err.code === "duplicate_repo") {
+            throw new ActionError(
+              "A bot with this name or repository already exists. Please choose a different name or repository.",
+            );
+          }
+          throw new ActionError(err.message);
+        }
+        throw err;
+      }
+
+      updateTag("bots");
+
+      return { slug: result.slug };
+    },
+  );

--- a/apps/cursor/src/actions/parse-github-bot.ts
+++ b/apps/cursor/src/actions/parse-github-bot.ts
@@ -1,0 +1,23 @@
+"use server";
+
+import { z } from "zod";
+import { BotParseError, parseGitHubBot } from "@/lib/bots/parse";
+import { ActionError, authActionClient } from "./safe-action";
+
+export const parseGitHubBotAction = authActionClient
+  .metadata({ actionName: "parse-github-bot" })
+  .schema(
+    z.object({
+      url: z.string().url("Please enter a valid GitHub URL"),
+    }),
+  )
+  .action(async ({ parsedInput: { url } }) => {
+    try {
+      return await parseGitHubBot(url, { maxWaitMs: 3000 });
+    } catch (err) {
+      if (err instanceof BotParseError) {
+        throw new ActionError(err.message);
+      }
+      throw err;
+    }
+  });

--- a/apps/cursor/src/actions/review-bot.ts
+++ b/apps/cursor/src/actions/review-bot.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { revalidatePath, updateTag } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/utils/supabase/admin-client";
+import { ActionError, adminActionClient } from "./safe-action";
+
+export const approveBotAction = adminActionClient
+  .metadata({ actionName: "approve-bot" })
+  .schema(z.object({ botId: z.string().uuid() }))
+  .action(async ({ parsedInput: { botId } }) => {
+    const supabase = await createClient();
+
+    const { error } = await supabase
+      .from("bots")
+      .update({ active: true })
+      .eq("id", botId);
+
+    if (error) {
+      throw new ActionError(`Failed to approve bot: ${error.message}`);
+    }
+
+    const { data: bot } = await supabase
+      .from("bots")
+      .select("slug")
+      .eq("id", botId)
+      .single();
+
+    revalidatePath("/admin/bots");
+    updateTag("bots");
+
+    if (bot?.slug) {
+      updateTag(`bot-${bot.slug}`);
+    }
+
+    return { success: true };
+  });
+
+export const declineBotAction = adminActionClient
+  .metadata({ actionName: "decline-bot" })
+  .schema(z.object({ botId: z.string().uuid() }))
+  .action(async ({ parsedInput: { botId } }) => {
+    const supabase = await createClient();
+
+    const { error } = await supabase.from("bots").delete().eq("id", botId);
+
+    if (error) {
+      throw new ActionError(`Failed to decline bot: ${error.message}`);
+    }
+
+    revalidatePath("/admin/bots");
+    updateTag("bots");
+
+    return { success: true };
+  });

--- a/apps/cursor/src/app/admin/bots/bot-review-list.tsx
+++ b/apps/cursor/src/app/admin/bots/bot-review-list.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { Check, ExternalLink, Loader2, Trash2 } from "lucide-react";
+import Link from "next/link";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { toast } from "sonner";
+import { approveBotAction, declineBotAction } from "@/actions/review-bot";
+import { Button } from "@/components/ui/button";
+import type { BotRow } from "@/lib/bots/types";
+
+function BotReviewCard({ bot }: { bot: BotRow }) {
+  const [dismissed, setDismissed] = useState(false);
+
+  const { execute: approve, isExecuting: isApproving } = useAction(
+    approveBotAction,
+    {
+      onSuccess: () => {
+        toast.success(`"${bot.name}" approved and now live.`);
+        setDismissed(true);
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? "Failed to approve bot.");
+      },
+    },
+  );
+
+  const { execute: decline, isExecuting: isDeclining } = useAction(
+    declineBotAction,
+    {
+      onSuccess: () => {
+        toast.success(`"${bot.name}" declined and removed.`);
+        setDismissed(true);
+      },
+      onError: ({ error }) => {
+        toast.error(error.serverError ?? "Failed to decline bot.");
+      },
+    },
+  );
+
+  if (dismissed) return null;
+
+  const busy = isApproving || isDeclining;
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-5 shadow-cursor">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/bots/${bot.slug}`}
+            target="_blank"
+            className="group flex items-center gap-1.5 truncate text-sm font-medium hover:underline"
+          >
+            {bot.name}
+            <ExternalLink className="size-3 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100" />
+          </Link>
+          <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+            {bot.description}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={busy}
+            onClick={() => decline({ botId: bot.id })}
+          >
+            {isDeclining ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Trash2 className="size-3.5" />
+            )}
+            <span className="ml-1.5">Decline</span>
+          </Button>
+          <Button
+            size="sm"
+            disabled={busy}
+            onClick={() => approve({ botId: bot.id })}
+          >
+            {isApproving ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <Check className="size-3.5" />
+            )}
+            <span className="ml-1.5">Approve</span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function BotReviewList({ bots }: { bots: BotRow[] }) {
+  if (bots.length === 0) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-10 text-center shadow-cursor">
+        <p className="text-sm text-muted-foreground">
+          No pending bots to review.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {bots.map((bot) => (
+        <BotReviewCard key={bot.id} bot={bot} />
+      ))}
+    </div>
+  );
+}

--- a/apps/cursor/src/app/admin/bots/page.tsx
+++ b/apps/cursor/src/app/admin/bots/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { getPendingBots } from "@/data/queries";
+import { isAdmin } from "@/utils/admin";
+import { getSession } from "@/utils/supabase/auth";
+import { BotReviewList } from "./bot-review-list";
+
+export const metadata: Metadata = {
+  title: "Review Bots | Admin",
+};
+
+async function AdminBotsContent() {
+  const session = await getSession();
+
+  if (!session || !isAdmin(session.user.id)) {
+    redirect("/");
+  }
+
+  const { data: pending } = await getPendingBots();
+
+  return <BotReviewList bots={pending ?? []} />;
+}
+
+export default function AdminBotsPage() {
+  return (
+    <div className="min-h-screen px-6 pt-24 md:pt-32 pb-32">
+      <div className="mx-auto w-full max-w-3xl">
+        <div className="mb-10">
+          <h1 className="marketing-page-title mb-3">Review Bots</h1>
+          <p className="marketing-copy text-muted-foreground">
+            Bot submissions land here unpublished. Scan is stubbed. Approve to
+            list the use case on /bots.
+          </p>
+        </div>
+        <Suspense fallback={null}>
+          <AdminBotsContent />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/cursor/src/app/bots/[slug]/page.tsx
+++ b/apps/cursor/src/app/bots/[slug]/page.tsx
@@ -36,10 +36,14 @@ export async function generateMetadata({
 }
 
 export async function generateStaticParams() {
-  const { data: bots } = await getBots({ fetchAll: true });
-  const slugs = new Set((bots ?? []).map((bot) => bot.slug));
-  slugs.add(SEED_BOT_SLUG);
-  return [...slugs].map((slug) => ({ slug }));
+  try {
+    const { data: bots } = await getBots({ fetchAll: true });
+    const slugs = new Set((bots ?? []).map((bot) => bot.slug));
+    slugs.add(SEED_BOT_SLUG);
+    return [...slugs].map((slug) => ({ slug }));
+  } catch {
+    return [{ slug: SEED_BOT_SLUG }];
+  }
 }
 
 export default async function Page({ params }: { params: Params }) {

--- a/apps/cursor/src/app/bots/[slug]/page.tsx
+++ b/apps/cursor/src/app/bots/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { BotDetailView } from "@/components/bots/bot-detail";
+import { getBotBySlug, getBots } from "@/data/queries";
+
+type Params = Promise<{ slug: string }>;
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Params;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const { data: bot } = await getBotBySlug(slug);
+
+  if (bot?.active) {
+    const title = `${bot.name} | Cursor Directory`;
+    const description = bot.description;
+    return {
+      title,
+      description,
+      openGraph: { title, description },
+      twitter: { title, description },
+    };
+  }
+
+  if (bot && !bot.active) {
+    return {
+      title: `${bot.name} | Cursor Directory`,
+      robots: { index: false },
+    };
+  }
+
+  return { title: "Bot Not Found" };
+}
+
+export async function generateStaticParams() {
+  const { data: bots } = await getBots({ fetchAll: true });
+  return (bots ?? []).map((bot) => ({ slug: bot.slug }));
+}
+
+export default async function Page({ params }: { params: Params }) {
+  const { slug } = await params;
+  const { data: bot } = await getBotBySlug(slug);
+  if (!bot) notFound();
+  return <BotDetailView bot={bot} />;
+}

--- a/apps/cursor/src/app/bots/[slug]/page.tsx
+++ b/apps/cursor/src/app/bots/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { BotDetailView } from "@/components/bots/bot-detail";
 import { getBotBySlug, getBots } from "@/data/queries";
+import { SEED_BOT_SLUG } from "@/lib/bots/seed";
 
 type Params = Promise<{ slug: string }>;
 
@@ -36,7 +37,9 @@ export async function generateMetadata({
 
 export async function generateStaticParams() {
   const { data: bots } = await getBots({ fetchAll: true });
-  return (bots ?? []).map((bot) => ({ slug: bot.slug }));
+  const slugs = new Set((bots ?? []).map((bot) => bot.slug));
+  slugs.add(SEED_BOT_SLUG);
+  return [...slugs].map((slug) => ({ slug }));
 }
 
 export default async function Page({ params }: { params: Params }) {

--- a/apps/cursor/src/app/bots/new/page.tsx
+++ b/apps/cursor/src/app/bots/new/page.tsx
@@ -1,0 +1,58 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+import { BotForm } from "@/components/forms/bot-form";
+import { getSession } from "@/utils/supabase/auth";
+
+export const metadata: Metadata = {
+  title: "Submit a Bot | Cursor Directory",
+  description:
+    "Submit a bot use case to Cursor Directory. Paste a GitHub repo with bot.json or BOT.md.",
+  openGraph: {
+    title: "Submit a Bot | Cursor Directory",
+    description:
+      "Submit a bot use case to Cursor Directory. Paste a GitHub repo with bot.json or BOT.md.",
+  },
+  twitter: {
+    title: "Submit a Bot | Cursor Directory",
+    description:
+      "Submit a bot use case to Cursor Directory. Paste a GitHub repo with bot.json or BOT.md.",
+  },
+};
+
+async function NewBotGate() {
+  const session = await getSession();
+
+  if (!session) {
+    redirect("/login?next=/bots/new");
+  }
+
+  return <BotForm />;
+}
+
+export default function Page() {
+  return (
+    <div className="min-h-screen px-6 pt-24 md:pt-32 pb-32">
+      <div className="mx-auto w-full max-w-lg">
+        <div className="mb-10 text-center">
+          <h1 className="marketing-page-title mb-3">Submit a Bot</h1>
+          <p className="marketing-copy mx-auto max-w-md">
+            Paste a GitHub repo. We look for bot.json or BOT.md plus a use-case
+            writeup. Open Plugins agents/*.md files belong on{" "}
+            <a
+              href="/plugins/new"
+              className="text-foreground border-b border-border border-dashed"
+            >
+              plugin submit
+            </a>
+            .
+          </p>
+        </div>
+
+        <Suspense fallback={null}>
+          <NewBotGate />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/apps/cursor/src/app/bots/page.tsx
+++ b/apps/cursor/src/app/bots/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
+import Link from "next/link";
+import { BotList } from "@/components/bots/bot-list";
+import { Button } from "@/components/ui/button";
+import { getBots } from "@/data/queries";
+
+export const metadata: Metadata = {
+  title: "Bots",
+  description:
+    "Copyable Cursor bot templates composed with the plugins and skills they need. Use-case pages from the community.",
+  openGraph: {
+    title: "Bots | Cursor Directory",
+    description:
+      "Copyable Cursor bot templates composed with the plugins and skills they need.",
+  },
+  twitter: {
+    title: "Bots | Cursor Directory",
+    description:
+      "Copyable Cursor bot templates composed with the plugins and skills they need.",
+  },
+};
+
+export default async function Page() {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("bots");
+
+  const { data: bots } = await getBots({ fetchAll: true });
+
+  return (
+    <div className="page-shell min-h-screen pb-32 pt-24 md:pt-32">
+      <div className="mb-10 flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div className="space-y-2">
+          <h1 className="marketing-page-title">Bots</h1>
+          <p className="marketing-copy max-w-2xl">
+            Use-case pages. Each one is a copyable bot template, the plugins and
+            skills it needs, and a writeup you can rank for search.
+          </p>
+        </div>
+        <Link href="/bots/new">
+          <Button variant="default" className="h-8 rounded-full px-4">
+            Submit a bot
+          </Button>
+        </Link>
+      </div>
+      <BotList bots={bots ?? []} />
+    </div>
+  );
+}

--- a/apps/cursor/src/app/layout.tsx
+++ b/apps/cursor/src/app/layout.tsx
@@ -19,7 +19,7 @@ export const metadata: Metadata = {
     template: "%s | Cursor Directory",
   },
   description:
-    "Discover plugins, MCP servers, rules, and resources for Cursor — the AI code editor. Join thousands of developers.",
+    "Discover plugins, bots, MCP servers, rules, and resources for Cursor. Join thousands of developers.",
   icons: [
     {
       rel: "icon",
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Cursor Directory",
     description:
-      "Discover plugins, MCP servers, rules, and resources for Cursor — the AI code editor.",
+      "Discover plugins, bots, MCP servers, rules, and resources for Cursor.",
     url: "https://cursor.directory",
     siteName: "Cursor Directory",
     locale: "en_US",
@@ -40,7 +40,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Cursor Directory",
     description:
-      "Discover plugins, MCP servers, rules, and resources for Cursor — the AI code editor.",
+      "Discover plugins, bots, MCP servers, rules, and resources for Cursor.",
   },
 };
 

--- a/apps/cursor/src/app/sitemap.ts
+++ b/apps/cursor/src/app/sitemap.ts
@@ -1,13 +1,13 @@
 import type { MetadataRoute } from "next";
 import { cacheLife, cacheTag } from "next/cache";
-import { getCompanies, getPlugins } from "@/data/queries";
+import { getBots, getCompanies, getPlugins } from "@/data/queries";
 
 const BASE_URL = "https://cursor.directory";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   "use cache";
   cacheLife("hours");
-  cacheTag("plugins", "companies");
+  cacheTag("plugins", "companies", "bots");
 
   const routes: MetadataRoute.Sitemap = [
     {
@@ -18,6 +18,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     },
     {
       url: `${BASE_URL}/learn`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/bots`,
       lastModified: new Date(),
       changeFrequency: "daily",
       priority: 0.9,
@@ -48,6 +54,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       routes.push({
         url: `${BASE_URL}/plugins/${plugin.slug}`,
         lastModified: new Date(plugin.updated_at),
+        changeFrequency: "weekly",
+        priority: 0.7,
+      });
+    }
+  }
+
+  const { data: bots } = await getBots({ fetchAll: true });
+  if (bots) {
+    for (const bot of bots) {
+      routes.push({
+        url: `${BASE_URL}/bots/${bot.slug}`,
+        lastModified: new Date(bot.updated_at),
         changeFrequency: "weekly",
         priority: 0.7,
       });

--- a/apps/cursor/src/components/bots/bot-detail.tsx
+++ b/apps/cursor/src/components/bots/bot-detail.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { CopyButton } from "@/components/plugins/detail/copy-button";
+import type { BotDetail } from "@/lib/bots/types";
+
+export function BotDetailView({ bot }: { bot: BotDetail }) {
+  const plugins = bot.needs.filter((n) => n.kind === "plugin");
+  const skills = bot.needs.filter((n) => n.kind === "skill");
+
+  return (
+    <div className="min-h-screen px-4 pt-24 md:pt-32">
+      <div className="page-shell max-w-4xl px-0 py-8">
+        {!bot.active && (
+          <div className="mb-6 rounded-lg border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+            This bot is in the review queue. It is not listed on /bots until an
+            admin publishes it.
+          </div>
+        )}
+
+        <p className="section-eyebrow mb-3">Bot use case</p>
+        <h1 className="marketing-page-title mb-3">{bot.name}</h1>
+        <p className="marketing-copy mb-10 max-w-2xl">{bot.description}</p>
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-sm font-medium text-foreground">
+            Copy this template
+          </h2>
+          <ol className="mb-4 list-decimal space-y-1 pl-5 text-sm text-muted-foreground">
+            <li>Copy the template below.</li>
+            <li>Open Cursor agent chat and paste it.</li>
+            <li>
+              Install the plugins listed on this page if you do not have them.
+            </li>
+            <li>Give the agent the task (a PR URL, a repo, a file).</li>
+          </ol>
+          <div className="rounded-lg border border-border bg-card">
+            <div className="flex items-center justify-between border-b border-border px-4 py-2">
+              <span className="text-xs text-muted-foreground">Template</span>
+              <CopyButton text={bot.template} />
+            </div>
+            <pre className="overflow-x-auto whitespace-pre-wrap p-4 text-sm text-foreground">
+              {bot.template}
+            </pre>
+          </div>
+        </section>
+
+        {(plugins.length > 0 || skills.length > 0) && (
+          <section className="mb-10">
+            <h2 className="mb-3 text-sm font-medium text-foreground">
+              Plugins and skills it needs
+            </h2>
+            <ul className="space-y-2">
+              {plugins.map((need) => (
+                <li
+                  key={`plugin-${need.slug ?? need.name}`}
+                  className="flex items-baseline justify-between gap-4 rounded-md border border-border px-4 py-3"
+                >
+                  <div>
+                    <p className="text-sm text-foreground">{need.name}</p>
+                    <p className="text-xs text-muted-foreground">Plugin</p>
+                  </div>
+                  {need.href ? (
+                    <Link
+                      href={need.href}
+                      className="border-b border-dashed border-border text-sm text-muted-foreground hover:text-foreground"
+                    >
+                      Open listing
+                    </Link>
+                  ) : need.repository ? (
+                    <a
+                      href={need.repository}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="border-b border-dashed border-border text-sm text-muted-foreground hover:text-foreground"
+                    >
+                      Repository
+                    </a>
+                  ) : (
+                    <span className="text-xs text-muted-foreground">
+                      Not in the directory yet
+                    </span>
+                  )}
+                </li>
+              ))}
+              {skills.map((need) => (
+                <li
+                  key={`skill-${need.name}`}
+                  className="rounded-md border border-border px-4 py-3"
+                >
+                  <p className="text-sm text-foreground">{need.name}</p>
+                  <p className="text-xs text-muted-foreground">Skill</p>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="mb-10">
+          <h2 className="mb-3 text-sm font-medium text-foreground">Use case</h2>
+          <div className="marketing-copy max-w-2xl whitespace-pre-wrap">
+            {bot.writeup}
+          </div>
+        </section>
+
+        {bot.repository && (
+          <a
+            href={bot.repository}
+            target="_blank"
+            rel="noreferrer"
+            className="border-b border-dashed border-border text-sm text-muted-foreground hover:text-foreground"
+          >
+            Source repository
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/cursor/src/components/bots/bot-list.tsx
+++ b/apps/cursor/src/components/bots/bot-list.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import Link from "next/link";
+import type { BotRow } from "@/lib/bots/types";
+
+export function BotList({ bots }: { bots: BotRow[] }) {
+  if (bots.length === 0) {
+    return (
+      <div className="mt-16 flex flex-col items-center">
+        <p className="text-sm text-muted-foreground">No bot use cases yet.</p>
+        <Link
+          href="/bots/new"
+          className="mt-2 border-b border-dashed border-input text-sm text-muted-foreground hover:text-foreground"
+        >
+          Submit a bot
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="mx-auto flex w-full max-w-[880px] flex-col gap-3">
+      {bots.map((bot) => (
+        <li key={bot.id}>
+          <Link
+            href={`/bots/${bot.slug}`}
+            className="block rounded-lg border border-border bg-card p-5 transition-colors hover:border-foreground/20"
+          >
+            <h2 className="text-base font-medium text-foreground">
+              {bot.name}
+            </h2>
+            <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+              {bot.description}
+            </p>
+            {bot.needs.length > 0 && (
+              <p className="mt-3 text-xs text-muted-foreground">
+                {bot.needs
+                  .map((need) =>
+                    need.kind === "plugin"
+                      ? `Plugin: ${need.name}`
+                      : `Skill: ${need.name}`,
+                  )
+                  .join(" · ")}
+              </p>
+            )}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/cursor/src/components/footer.tsx
+++ b/apps/cursor/src/components/footer.tsx
@@ -10,6 +10,7 @@ const columns = [
     title: "Explore",
     links: [
       { href: "/", label: "Plugins" },
+      { href: "/bots", label: "Bots" },
       { href: "/plugins/new", label: "Submit a Plugin" },
     ],
   },
@@ -49,6 +50,7 @@ const columns = [
     title: "Contribute",
     links: [
       { href: "/plugins/new", label: "Submit a Plugin" },
+      { href: "/bots/new", label: "Submit a Bot" },
       {
         href: "https://github.com/cursor/community-plugins",
         label: "GitHub",

--- a/apps/cursor/src/components/forms/bot-form.tsx
+++ b/apps/cursor/src/components/forms/bot-form.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle, Loader2 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useAction } from "next-safe-action/hooks";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
+import { createBotAction } from "@/actions/create-bot";
+import { parseGitHubBotAction } from "@/actions/parse-github-bot";
+import { GithubIcon } from "@/components/icons/github-icon";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import type { ParsedBot } from "@/lib/bots/parse";
+import type { BotNeed } from "@/lib/bots/types";
+import { slugify } from "@/lib/slug";
+
+const autoFormSchema = z.object({
+  url: z
+    .string()
+    .url("Please enter a valid URL")
+    .regex(/github\.com/, "Must be a GitHub URL"),
+});
+
+function parseNeedList(pluginsRaw: string, skillsRaw: string): BotNeed[] {
+  const plugins = pluginsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((name) => ({ kind: "plugin" as const, name, slug: slugify(name) }));
+  const skills = skillsRaw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((name) => ({ kind: "skill" as const, name }));
+  return [...plugins, ...skills];
+}
+
+export function BotForm() {
+  const router = useRouter();
+  const [mode, setMode] = useState<"auto" | "manual">("auto");
+  const [parsed, setParsed] = useState<ParsedBot | null>(null);
+  const [editedName, setEditedName] = useState("");
+  const [editedDescription, setEditedDescription] = useState("");
+  const [editedWriteup, setEditedWriteup] = useState("");
+  const [editedTemplate, setEditedTemplate] = useState("");
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [publishError, setPublishError] = useState<string | null>(null);
+
+  const [manualName, setManualName] = useState("");
+  const [manualDescription, setManualDescription] = useState("");
+  const [manualWriteup, setManualWriteup] = useState("");
+  const [manualTemplate, setManualTemplate] = useState("");
+  const [manualRepository, setManualRepository] = useState("");
+  const [manualPlugins, setManualPlugins] = useState("");
+  const [manualSkills, setManualSkills] = useState("");
+
+  const form = useForm<z.infer<typeof autoFormSchema>>({
+    resolver: zodResolver(autoFormSchema),
+    defaultValues: { url: "" },
+  });
+
+  const { execute: executeParse, isExecuting: isParsing } = useAction(
+    parseGitHubBotAction,
+    {
+      onSuccess: ({ data }) => {
+        if (data) {
+          setParsed(data);
+          setEditedName(data.name);
+          setEditedDescription(data.description);
+          setEditedWriteup(data.writeup);
+          setEditedTemplate(data.template);
+          setParseError(null);
+        }
+      },
+      onError: ({ error }) => {
+        setParseError(error.serverError ?? "Failed to parse repository");
+        setParsed(null);
+      },
+    },
+  );
+
+  const { execute: executeCreate, isExecuting: isCreating } = useAction(
+    createBotAction,
+    {
+      onSuccess: ({ data }) => {
+        toast.success("Submitted. It will appear on /bots after review.");
+        router.push(data?.slug ? `/bots/${data.slug}` : "/bots");
+      },
+      onError: ({ error }) => {
+        setPublishError(
+          error.serverError ?? "Failed to submit bot. Please try again.",
+        );
+      },
+    },
+  );
+
+  const onParse = (values: z.infer<typeof autoFormSchema>) => {
+    setParseError(null);
+    setPublishError(null);
+    setParsed(null);
+    executeParse({ url: values.url });
+  };
+
+  const onPublishAuto = () => {
+    if (!parsed) return;
+    setPublishError(null);
+    executeCreate({
+      name: editedName || parsed.name,
+      description: editedDescription || parsed.description,
+      writeup: editedWriteup || parsed.writeup,
+      template: editedTemplate || parsed.template,
+      needs: parsed.needs,
+      repository: parsed.repository,
+      homepage: parsed.homepage ?? null,
+    });
+  };
+
+  const onPublishManual = () => {
+    setPublishError(null);
+    executeCreate({
+      name: manualName.trim(),
+      description: manualDescription.trim(),
+      writeup: manualWriteup.trim(),
+      template: manualTemplate.trim(),
+      needs: parseNeedList(manualPlugins, manualSkills),
+      repository: manualRepository.trim() || null,
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      <Tabs
+        value={mode}
+        onValueChange={(v) => {
+          if (v !== "auto" && v !== "manual") return;
+          setMode(v);
+          setPublishError(null);
+        }}
+      >
+        <TabsList className="w-full">
+          <TabsTrigger value="auto" className="flex-1">
+            Auto (GitHub)
+          </TabsTrigger>
+          <TabsTrigger value="manual" className="flex-1">
+            Manual
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="auto" className="mt-6">
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onParse)} className="space-y-4">
+              <FormField
+                control={form.control}
+                name="url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <div className="flex items-center gap-2">
+                        <div className="relative flex-1">
+                          <GithubIcon className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                          <Input
+                            placeholder="https://github.com/you/your-bot"
+                            {...field}
+                            className="border-border pl-10 placeholder:text-[#878787]"
+                            disabled={isParsing}
+                          />
+                        </div>
+                        <Button
+                          type="submit"
+                          disabled={isParsing}
+                          className="h-11 flex-shrink-0"
+                        >
+                          {isParsing ? (
+                            <>
+                              <Loader2 className="size-4 animate-spin mr-2" />
+                              Scanning...
+                            </>
+                          ) : parsed ? (
+                            "Re-scan"
+                          ) : (
+                            "Scan repo"
+                          )}
+                        </Button>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </form>
+          </Form>
+
+          {parseError && (
+            <div className="mt-6 flex items-start gap-3 rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+              <AlertCircle className="mt-0.5 size-4 shrink-0 text-red-400" />
+              <p className="text-sm text-red-400">{parseError}</p>
+            </div>
+          )}
+
+          {parsed && (
+            <div className="mt-6 space-y-4">
+              <div>
+                <label
+                  htmlFor="auto-bot-name"
+                  className="mb-1.5 block text-sm font-medium"
+                >
+                  Name
+                </label>
+                <Input
+                  id="auto-bot-name"
+                  value={editedName}
+                  onChange={(e) => setEditedName(e.target.value)}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="auto-bot-description"
+                  className="mb-1.5 block text-sm font-medium"
+                >
+                  Description
+                </label>
+                <Input
+                  id="auto-bot-description"
+                  value={editedDescription}
+                  onChange={(e) => setEditedDescription(e.target.value)}
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="auto-bot-writeup"
+                  className="mb-1.5 block text-sm font-medium"
+                >
+                  Use-case writeup
+                </label>
+                <Textarea
+                  id="auto-bot-writeup"
+                  value={editedWriteup}
+                  onChange={(e) => setEditedWriteup(e.target.value)}
+                  className="min-h-32"
+                />
+              </div>
+              <div>
+                <label
+                  htmlFor="auto-bot-template"
+                  className="mb-1.5 block text-sm font-medium"
+                >
+                  Template
+                </label>
+                <Textarea
+                  id="auto-bot-template"
+                  value={editedTemplate}
+                  onChange={(e) => setEditedTemplate(e.target.value)}
+                  className="min-h-32 font-mono text-sm"
+                />
+              </div>
+              {parsed.needs.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Detected needs:{" "}
+                  {parsed.needs
+                    .map((n) =>
+                      n.kind === "plugin"
+                        ? `plugin ${n.name}`
+                        : `skill ${n.name}`,
+                    )
+                    .join(", ")}
+                </p>
+              )}
+              {publishError && (
+                <p className="text-sm text-red-400">{publishError}</p>
+              )}
+              <Button
+                onClick={onPublishAuto}
+                size="lg"
+                disabled={isCreating || !editedName.trim()}
+                className="w-full"
+              >
+                {isCreating ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin mr-2" />
+                    Submitting...
+                  </>
+                ) : (
+                  "Submit bot"
+                )}
+              </Button>
+            </div>
+          )}
+
+          {!parsed && !parseError && (
+            <p className="pt-4 text-center text-xs text-muted-foreground">
+              We look for bot.json or BOT.md plus a writeup. Open Plugins
+              agents/*.md files are plugins. Submit those at /plugins/new.
+            </p>
+          )}
+        </TabsContent>
+
+        <TabsContent value="manual" className="mt-6 space-y-4">
+          <Input
+            placeholder="Name"
+            value={manualName}
+            onChange={(e) => setManualName(e.target.value)}
+          />
+          <Input
+            placeholder="Short description"
+            value={manualDescription}
+            onChange={(e) => setManualDescription(e.target.value)}
+          />
+          <Textarea
+            placeholder="Use-case writeup (this is the SEO page body)"
+            value={manualWriteup}
+            onChange={(e) => setManualWriteup(e.target.value)}
+            className="min-h-32"
+          />
+          <Textarea
+            placeholder="Copyable bot template"
+            value={manualTemplate}
+            onChange={(e) => setManualTemplate(e.target.value)}
+            className="min-h-32 font-mono text-sm"
+          />
+          <Input
+            placeholder="GitHub repo URL (optional)"
+            value={manualRepository}
+            onChange={(e) => setManualRepository(e.target.value)}
+          />
+          <Input
+            placeholder="Plugin names, comma-separated"
+            value={manualPlugins}
+            onChange={(e) => setManualPlugins(e.target.value)}
+          />
+          <Input
+            placeholder="Skill names, comma-separated"
+            value={manualSkills}
+            onChange={(e) => setManualSkills(e.target.value)}
+          />
+          {publishError && (
+            <p className="text-sm text-red-400">{publishError}</p>
+          )}
+          <Button
+            onClick={onPublishManual}
+            size="lg"
+            disabled={
+              isCreating ||
+              manualName.trim().length < 2 ||
+              manualDescription.trim().length < 10 ||
+              manualWriteup.trim().length < 40 ||
+              manualTemplate.trim().length < 20
+            }
+            className="w-full"
+          >
+            {isCreating ? "Submitting..." : "Submit bot"}
+          </Button>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/cursor/src/components/header.tsx
+++ b/apps/cursor/src/components/header.tsx
@@ -16,6 +16,11 @@ export const navigationLinks = [
     match: (p: string) => p === "/" || p.startsWith("/plugins"),
   },
   {
+    href: "/bots",
+    label: "Bots",
+    match: (p: string) => p === "/bots" || p.startsWith("/bots/"),
+  },
+  {
     href: "/members",
     label: "Members",
     match: (p: string) => p === "/members" || p.startsWith("/members/"),

--- a/apps/cursor/src/components/mobile-menu.tsx
+++ b/apps/cursor/src/components/mobile-menu.tsx
@@ -118,6 +118,14 @@ export function MobileMenu() {
                   Submit a plugin
                 </Button>
               </Link>
+              <Link href="/bots/new" onClick={() => setIsOpen(false)}>
+                <Button
+                  variant="outline"
+                  className="mt-3 h-9 w-full rounded-full"
+                >
+                  Submit a bot
+                </Button>
+              </Link>
 
               <div className="mt-12">
                 {user ? (

--- a/apps/cursor/src/components/user-menu.tsx
+++ b/apps/cursor/src/components/user-menu.tsx
@@ -120,6 +120,9 @@ export function UserMenu() {
               <DropdownMenuItem asChild>
                 <Link href="/plugins/new">Submit a plugin</Link>
               </DropdownMenuItem>
+              <DropdownMenuItem asChild>
+                <Link href="/bots/new">Submit a bot</Link>
+              </DropdownMenuItem>
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger>Theme</DropdownMenuSubTrigger>
                 <DropdownMenuPortal>

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -687,10 +687,6 @@ export async function getMembers({
   return { data, error };
 }
 
-// ---------------------------------------------------------------------------
-// Bots (use-case listings)
-// ---------------------------------------------------------------------------
-
 export async function getBots({
   fetchAll = true,
 }: {

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -80,6 +80,16 @@ function asBotRow(row: Record<string, unknown>): BotRow {
   };
 }
 
+function unresolvedBotNeeds(needs: BotNeed[]): ResolvedBotNeed[] {
+  return needs.map((need) => {
+    if (need.kind === "skill") return need;
+    return {
+      ...need,
+      href: need.slug ? `/plugins/${need.slug}` : null,
+    };
+  });
+}
+
 async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
   const slugs = needs.flatMap((n) =>
     n.kind === "plugin" && n.slug ? [n.slug] : [],
@@ -87,14 +97,18 @@ async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
   const hrefBySlug = new Map<string, string>();
 
   if (slugs.length > 0) {
-    const supabase = await createClient();
-    const { data } = await supabase
-      .from("plugins")
-      .select("slug")
-      .eq("active", true)
-      .in("slug", slugs);
-    for (const plugin of data ?? []) {
-      hrefBySlug.set(plugin.slug, `/plugins/${plugin.slug}`);
+    try {
+      const supabase = await createClient();
+      const { data } = await supabase
+        .from("plugins")
+        .select("slug")
+        .eq("active", true)
+        .in("slug", slugs);
+      for (const plugin of data ?? []) {
+        hrefBySlug.set(plugin.slug, `/plugins/${plugin.slug}`);
+      }
+    } catch {
+      return unresolvedBotNeeds(needs);
     }
   }
 
@@ -105,6 +119,10 @@ async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
       href: need.slug ? (hrefBySlug.get(need.slug) ?? null) : null,
     };
   });
+}
+
+async function seedBotDetail(): Promise<BotDetail> {
+  return { ...SEED_BOT, needs: await resolveBotNeeds(SEED_BOT.needs) };
 }
 
 async function fetchUserProfile(slug: string, userId?: string) {
@@ -701,43 +719,49 @@ export async function getBots({
   cacheLife("hours");
   cacheTag("bots");
 
-  const supabase = await createClient();
+  try {
+    const supabase = await createClient();
 
-  const baseQuery = () =>
-    supabase
-      .from("bots")
-      .select("*")
-      .eq("active", true)
-      .order("created_at", { ascending: false });
+    const baseQuery = () =>
+      supabase
+        .from("bots")
+        .select("*")
+        .eq("active", true)
+        .order("created_at", { ascending: false });
 
-  if (fetchAll) {
-    const result = await fetchAllPages<Record<string, unknown>>(
-      async (from, to) => {
-        const { data, error } = await baseQuery().range(from, to);
-        return { data: data as Record<string, unknown>[] | null, error };
-      },
-      100,
-    );
-    if (result.error || !result.data) {
-      if (isMissingRelationError(result.error, "bots")) {
-        return { data: [SEED_BOT], error: null };
+    if (fetchAll) {
+      const result = await fetchAllPages<Record<string, unknown>>(
+        async (from, to) => {
+          const { data, error } = await baseQuery().range(from, to);
+          return { data: data as Record<string, unknown>[] | null, error };
+        },
+        100,
+      );
+      if (result.error || !result.data) {
+        if (isMissingRelationError(result.error, "bots")) {
+          return { data: [SEED_BOT], error: null };
+        }
+        return { data: null, error: result.error };
       }
-      return { data: null, error: result.error };
+      return {
+        data: result.data.map(asBotRow),
+        error: null,
+      };
+    }
+
+    const { data, error } = await baseQuery();
+    if (error && isMissingRelationError(error, "bots")) {
+      return { data: [SEED_BOT], error: null };
     }
     return {
-      data: result.data.map(asBotRow),
-      error: null,
+      data: (data ?? []).map((row) => asBotRow(row as Record<string, unknown>)),
+      error,
     };
-  }
-
-  const { data, error } = await baseQuery();
-  if (error && isMissingRelationError(error, "bots")) {
+  } catch {
+    // Cache Components prerenders /bots. A thrown client error must not 500
+    // the preview build when public.bots is missing or the query dies.
     return { data: [SEED_BOT], error: null };
   }
-  return {
-    data: (data ?? []).map((row) => asBotRow(row as Record<string, unknown>)),
-    error,
-  };
 }
 
 export async function getBotBySlug(slug: string): Promise<{
@@ -748,58 +772,71 @@ export async function getBotBySlug(slug: string): Promise<{
   cacheLife("hours");
   cacheTag("bots", `bot-${slug}`, "plugins");
 
-  const supabase = await createClient();
-  const { data, error } = await supabase
-    .from("bots")
-    .select("*")
-    .eq("slug", slug)
-    .single();
+  try {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("bots")
+      .select("*")
+      .eq("slug", slug)
+      .single();
 
-  if (error && isMissingRelationError(error, "bots")) {
-    if (slug !== SEED_BOT_SLUG) return { data: null, error: null };
+    if (error && isMissingRelationError(error, "bots")) {
+      if (slug !== SEED_BOT_SLUG) return { data: null, error: null };
+      return { data: await seedBotDetail(), error: null };
+    }
+
+    if (!data) {
+      if (slug === SEED_BOT_SLUG) {
+        return { data: await seedBotDetail(), error: null };
+      }
+      return { data: null, error };
+    }
+
+    const bot = asBotRow(data as Record<string, unknown>);
     return {
-      data: { ...SEED_BOT, needs: await resolveBotNeeds(SEED_BOT.needs) },
-      error: null,
+      data: { ...bot, needs: await resolveBotNeeds(bot.needs) },
+      error,
     };
+  } catch (error) {
+    if (slug === SEED_BOT_SLUG) {
+      return { data: await seedBotDetail(), error: null };
+    }
+    return { data: null, error };
   }
-
-  if (!data) return { data: null, error };
-
-  const bot = asBotRow(data as Record<string, unknown>);
-  return {
-    data: { ...bot, needs: await resolveBotNeeds(bot.needs) },
-    error,
-  };
 }
 
 export async function getPendingBots(): Promise<{
   data: BotRow[] | null;
   error: unknown;
 }> {
-  const supabase = await createClient();
+  try {
+    const supabase = await createClient();
 
-  const result = await fetchAllPages<Record<string, unknown>>(
-    async (from, to) => {
-      const { data, error } = await supabase
-        .from("bots")
-        .select("*")
-        .eq("active", false)
-        .order("created_at", { ascending: false })
-        .range(from, to);
-      return { data: data as Record<string, unknown>[] | null, error };
-    },
-    100,
-  );
+    const result = await fetchAllPages<Record<string, unknown>>(
+      async (from, to) => {
+        const { data, error } = await supabase
+          .from("bots")
+          .select("*")
+          .eq("active", false)
+          .order("created_at", { ascending: false })
+          .range(from, to);
+        return { data: data as Record<string, unknown>[] | null, error };
+      },
+      100,
+    );
 
-  if (result.error || !result.data) {
-    if (isMissingRelationError(result.error, "bots")) {
-      return { data: [], error: null };
+    if (result.error || !result.data) {
+      if (isMissingRelationError(result.error, "bots")) {
+        return { data: [], error: null };
+      }
+      return { data: null, error: result.error };
     }
-    return { data: null, error: result.error };
-  }
 
-  return {
-    data: result.data.map(asBotRow),
-    error: null,
-  };
+    return {
+      data: result.data.map(asBotRow),
+      error: null,
+    };
+  } catch {
+    return { data: [], error: null };
+  }
 }

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -23,12 +23,84 @@
  *   companies          — company lists
  *   company-{slug}     — a single company profile
  *   mcps               — MCP listings
+ *   bots               — bot use-case listings
+ *   bot-{slug}         — a single bot
  */
 
 import { cacheLife, cacheTag } from "next/cache";
+import {
+  type BotDetail,
+  type BotNeed,
+  type BotRow,
+  parseBotNeeds,
+  parseScanStatus,
+  type ResolvedBotNeed,
+} from "@/lib/bots/types";
 import type { PluginRow } from "@/lib/plugins/types";
 import { createClient } from "@/utils/supabase/admin-client";
 import { fetchAllPages } from "@/utils/supabase/pagination";
+
+function asOptionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function asOptionalNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value !== "") {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
+}
+
+function asBotRow(row: Record<string, unknown>): BotRow {
+  return {
+    id: String(row.id),
+    name: String(row.name),
+    slug: String(row.slug),
+    description: String(row.description ?? ""),
+    writeup: String(row.writeup ?? ""),
+    template: String(row.template ?? ""),
+    needs: parseBotNeeds(row.needs),
+    repository: asOptionalString(row.repository),
+    homepage: asOptionalString(row.homepage),
+    logo: asOptionalString(row.logo),
+    owner_id: asOptionalString(row.owner_id),
+    active: Boolean(row.active),
+    scan_status: parseScanStatus(row.scan_status),
+    discovery_source: asOptionalString(row.discovery_source),
+    github_repo_id: asOptionalNumber(row.github_repo_id),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
+  const slugs = needs.flatMap((n) =>
+    n.kind === "plugin" && n.slug ? [n.slug] : [],
+  );
+  const hrefBySlug = new Map<string, string>();
+
+  if (slugs.length > 0) {
+    const supabase = await createClient();
+    const { data } = await supabase
+      .from("plugins")
+      .select("slug")
+      .eq("active", true)
+      .in("slug", slugs);
+    for (const plugin of data ?? []) {
+      hrefBySlug.set(plugin.slug, `/plugins/${plugin.slug}`);
+    }
+  }
+
+  return needs.map((need) => {
+    if (need.kind === "skill") return need;
+    return {
+      ...need,
+      href: need.slug ? (hrefBySlug.get(need.slug) ?? null) : null,
+    };
+  });
+}
 
 async function fetchUserProfile(slug: string, userId?: string) {
   const supabase = await createClient();
@@ -613,4 +685,103 @@ export async function getMembers({
   const { data, error } = await query;
 
   return { data, error };
+}
+
+// ---------------------------------------------------------------------------
+// Bots (use-case listings)
+// ---------------------------------------------------------------------------
+
+export async function getBots({
+  fetchAll = true,
+}: {
+  fetchAll?: boolean;
+} = {}): Promise<{ data: BotRow[] | null; error: unknown }> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("bots");
+
+  const supabase = await createClient();
+
+  const baseQuery = () =>
+    supabase
+      .from("bots")
+      .select("*")
+      .eq("active", true)
+      .order("created_at", { ascending: false });
+
+  if (fetchAll) {
+    const result = await fetchAllPages<Record<string, unknown>>(
+      async (from, to) => {
+        const { data, error } = await baseQuery().range(from, to);
+        return { data: data as Record<string, unknown>[] | null, error };
+      },
+      100,
+    );
+    if (result.error || !result.data) {
+      return { data: null, error: result.error };
+    }
+    return {
+      data: result.data.map(asBotRow),
+      error: null,
+    };
+  }
+
+  const { data, error } = await baseQuery();
+  return {
+    data: (data ?? []).map((row) => asBotRow(row as Record<string, unknown>)),
+    error,
+  };
+}
+
+export async function getBotBySlug(slug: string): Promise<{
+  data: BotDetail | null;
+  error: unknown;
+}> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag("bots", `bot-${slug}`, "plugins");
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("bots")
+    .select("*")
+    .eq("slug", slug)
+    .single();
+
+  if (!data) return { data: null, error };
+
+  const bot = asBotRow(data as Record<string, unknown>);
+  return {
+    data: { ...bot, needs: await resolveBotNeeds(bot.needs) },
+    error,
+  };
+}
+
+export async function getPendingBots(): Promise<{
+  data: BotRow[] | null;
+  error: unknown;
+}> {
+  const supabase = await createClient();
+
+  const result = await fetchAllPages<Record<string, unknown>>(
+    async (from, to) => {
+      const { data, error } = await supabase
+        .from("bots")
+        .select("*")
+        .eq("active", false)
+        .order("created_at", { ascending: false })
+        .range(from, to);
+      return { data: data as Record<string, unknown>[] | null, error };
+    },
+    100,
+  );
+
+  if (result.error || !result.data) {
+    return { data: null, error: result.error };
+  }
+
+  return {
+    data: result.data.map(asBotRow),
+    error: null,
+  };
 }

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -80,16 +80,6 @@ function asBotRow(row: Record<string, unknown>): BotRow {
   };
 }
 
-function unresolvedBotNeeds(needs: BotNeed[]): ResolvedBotNeed[] {
-  return needs.map((need) => {
-    if (need.kind === "skill") return need;
-    return {
-      ...need,
-      href: need.slug ? `/plugins/${need.slug}` : null,
-    };
-  });
-}
-
 async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
   const slugs = needs.flatMap((n) =>
     n.kind === "plugin" && n.slug ? [n.slug] : [],
@@ -108,7 +98,7 @@ async function resolveBotNeeds(needs: BotNeed[]): Promise<ResolvedBotNeed[]> {
         hrefBySlug.set(plugin.slug, `/plugins/${plugin.slug}`);
       }
     } catch {
-      return unresolvedBotNeeds(needs);
+      // Leave hrefBySlug empty so href stays null, same as a missing plugin.
     }
   }
 
@@ -757,10 +747,11 @@ export async function getBots({
       data: (data ?? []).map((row) => asBotRow(row as Record<string, unknown>)),
       error,
     };
-  } catch {
-    // Cache Components prerenders /bots. A thrown client error must not 500
-    // the preview build when public.bots is missing or the query dies.
-    return { data: [SEED_BOT], error: null };
+  } catch (error) {
+    if (isMissingRelationError(error, "bots")) {
+      return { data: [SEED_BOT], error: null };
+    }
+    throw error;
   }
 }
 
@@ -785,12 +776,7 @@ export async function getBotBySlug(slug: string): Promise<{
       return { data: await seedBotDetail(), error: null };
     }
 
-    if (!data) {
-      if (slug === SEED_BOT_SLUG) {
-        return { data: await seedBotDetail(), error: null };
-      }
-      return { data: null, error };
-    }
+    if (!data) return { data: null, error };
 
     const bot = asBotRow(data as Record<string, unknown>);
     return {
@@ -798,10 +784,11 @@ export async function getBotBySlug(slug: string): Promise<{
       error,
     };
   } catch (error) {
-    if (slug === SEED_BOT_SLUG) {
+    if (isMissingRelationError(error, "bots")) {
+      if (slug !== SEED_BOT_SLUG) return { data: null, error: null };
       return { data: await seedBotDetail(), error: null };
     }
-    return { data: null, error };
+    throw error;
   }
 }
 
@@ -836,7 +823,10 @@ export async function getPendingBots(): Promise<{
       data: result.data.map(asBotRow),
       error: null,
     };
-  } catch {
-    return { data: [], error: null };
+  } catch (error) {
+    if (isMissingRelationError(error, "bots")) {
+      return { data: [], error: null };
+    }
+    throw error;
   }
 }

--- a/apps/cursor/src/data/queries.ts
+++ b/apps/cursor/src/data/queries.ts
@@ -29,6 +29,11 @@
 
 import { cacheLife, cacheTag } from "next/cache";
 import {
+  isMissingRelationError,
+  SEED_BOT,
+  SEED_BOT_SLUG,
+} from "@/lib/bots/seed";
+import {
   type BotDetail,
   type BotNeed,
   type BotRow,
@@ -714,6 +719,9 @@ export async function getBots({
       100,
     );
     if (result.error || !result.data) {
+      if (isMissingRelationError(result.error, "bots")) {
+        return { data: [SEED_BOT], error: null };
+      }
       return { data: null, error: result.error };
     }
     return {
@@ -723,6 +731,9 @@ export async function getBots({
   }
 
   const { data, error } = await baseQuery();
+  if (error && isMissingRelationError(error, "bots")) {
+    return { data: [SEED_BOT], error: null };
+  }
   return {
     data: (data ?? []).map((row) => asBotRow(row as Record<string, unknown>)),
     error,
@@ -743,6 +754,14 @@ export async function getBotBySlug(slug: string): Promise<{
     .select("*")
     .eq("slug", slug)
     .single();
+
+  if (error && isMissingRelationError(error, "bots")) {
+    if (slug !== SEED_BOT_SLUG) return { data: null, error: null };
+    return {
+      data: { ...SEED_BOT, needs: await resolveBotNeeds(SEED_BOT.needs) },
+      error: null,
+    };
+  }
 
   if (!data) return { data: null, error };
 
@@ -773,6 +792,9 @@ export async function getPendingBots(): Promise<{
   );
 
   if (result.error || !result.data) {
+    if (isMissingRelationError(result.error, "bots")) {
+      return { data: [], error: null };
+    }
     return { data: null, error: result.error };
   }
 

--- a/apps/cursor/src/lib/bots/insert.ts
+++ b/apps/cursor/src/lib/bots/insert.ts
@@ -1,0 +1,87 @@
+/**
+ * Insert a bot listing. The create-bot action owns auth and rate limits.
+ * Does not enqueue plugin_scans: that queue's drain runs runPluginScan
+ * and expects a plugins row.
+ */
+
+import { createClient } from "@/utils/supabase/admin-client";
+import { type BotNeed, botNeedsSchema } from "./types";
+
+export type InsertBotInput = {
+  name: string;
+  description: string;
+  writeup: string;
+  template: string;
+  needs?: BotNeed[];
+  repository?: string | null;
+  homepage?: string | null;
+  logo?: string | null;
+};
+
+export type InsertBotOptions = {
+  ownerId: string | null;
+  source: string;
+  githubRepoId?: number | null;
+  skipReview?: boolean;
+};
+
+export class InsertBotError extends Error {
+  constructor(
+    message: string,
+    public readonly code: "duplicate_name" | "duplicate_repo" | "insert_failed",
+  ) {
+    super(message);
+    this.name = "InsertBotError";
+  }
+}
+
+export async function insertBot(
+  input: InsertBotInput,
+  options: InsertBotOptions,
+): Promise<{ id: string; slug: string }> {
+  const supabase = await createClient();
+  const skipReview = options.skipReview === true;
+  const needs = botNeedsSchema.parse(input.needs ?? []);
+
+  const { data: bot, error } = await supabase
+    .from("bots")
+    .insert({
+      name: input.name,
+      description: input.description,
+      writeup: input.writeup,
+      template: input.template,
+      needs,
+      repository: input.repository || null,
+      homepage: input.homepage || null,
+      logo: input.logo || null,
+      owner_id: options.ownerId,
+      active: skipReview,
+      scan_status: skipReview ? "unscanned" : "pending",
+      discovery_source: options.source,
+      github_repo_id: options.githubRepoId ?? null,
+    })
+    .select("id, slug")
+    .single();
+
+  if (error) {
+    if (error.code === "23505") {
+      const detail = error.message?.toLowerCase() ?? "";
+      if (detail.includes("github_repo_id")) {
+        throw new InsertBotError(
+          "A bot with this GitHub repository already exists.",
+          "duplicate_repo",
+        );
+      }
+      throw new InsertBotError(
+        "A bot with this name already exists.",
+        "duplicate_name",
+      );
+    }
+    throw new InsertBotError(
+      `Failed to create bot: ${error.message}`,
+      "insert_failed",
+    );
+  }
+
+  return { id: bot.id, slug: bot.slug };
+}

--- a/apps/cursor/src/lib/bots/parse.ts
+++ b/apps/cursor/src/lib/bots/parse.ts
@@ -94,7 +94,29 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return null;
 }
 
-function parseNeeds(manifest: Record<string, unknown>): BotNeed[] {
+function parsePluginNeed(rec: Record<string, unknown>): BotNeed | null {
+  const name = typeof rec.name === "string" ? rec.name.trim() : "";
+  if (!name) return null;
+  const slug =
+    typeof rec.slug === "string" && rec.slug.trim()
+      ? rec.slug.trim()
+      : slugify(name);
+  const repository =
+    typeof rec.repository === "string" && rec.repository.trim()
+      ? rec.repository.trim()
+      : undefined;
+  const base = { kind: "plugin" as const, name, slug };
+  const withRepo = botNeedSchema.safeParse(
+    repository ? { ...base, repository } : base,
+  );
+  if (withRepo.success) return withRepo.data;
+  const withoutRepo = botNeedSchema.safeParse(base);
+  return withoutRepo.success ? withoutRepo.data : null;
+}
+
+export function parseBotManifestNeeds(
+  manifest: Record<string, unknown>,
+): BotNeed[] {
   const needs: BotNeed[] = [];
 
   const plugins = manifest.plugins;
@@ -107,19 +129,8 @@ function parseNeeds(manifest: Record<string, unknown>): BotNeed[] {
       }
       const rec = asRecord(entry);
       if (!rec) continue;
-      const name = typeof rec.name === "string" ? rec.name.trim() : "";
-      if (!name) continue;
-      const parsed = botNeedSchema.safeParse({
-        kind: "plugin",
-        name,
-        ...(typeof rec.slug === "string" && rec.slug.trim()
-          ? { slug: rec.slug.trim() }
-          : { slug: slugify(name) }),
-        ...(typeof rec.repository === "string" && rec.repository.trim()
-          ? { repository: rec.repository.trim() }
-          : {}),
-      });
-      if (parsed.success) needs.push(parsed.data);
+      const need = parsePluginNeed(rec);
+      if (need) needs.push(need);
     }
   }
 
@@ -172,6 +183,7 @@ export async function parseGitHubBot(
 
   let manifest: Record<string, unknown> = {};
   let foundManifest = false;
+  let lastInvalidJsonPath: string | null = null;
   for (const path of MANIFEST_PATHS) {
     const content = await fetchGitHubFile(owner, repo, path);
     if (!content) continue;
@@ -184,7 +196,7 @@ export async function parseGitHubBot(
         break;
       }
     } catch {
-      throw new BotParseError(`Could not parse ${path} as JSON.`, "no_bot");
+      lastInvalidJsonPath = path;
     }
   }
 
@@ -227,8 +239,11 @@ export async function parseGitHubBot(
         "open_plugin_agent",
       );
     }
+    const jsonHint = lastInvalidJsonPath
+      ? ` ${lastInvalidJsonPath} was not valid JSON.`
+      : "";
     throw new BotParseError(
-      "No bot listing found. Add bot.json (name, description, template, writeup, plugins, skills) or BOT.md plus a README/WRITEUP.md. Open Plugins `agents/*.md` files are plugins, not bots.",
+      `No bot listing found.${jsonHint} Add bot.json (name, description, template, writeup, plugins, skills) or BOT.md plus a README/WRITEUP.md. Open Plugins \`agents/*.md\` files are plugins, not bots.`,
       "no_bot",
     );
   }
@@ -245,7 +260,7 @@ export async function parseGitHubBot(
     description: description.slice(0, 280),
     writeup,
     template,
-    needs: parseNeeds(manifest),
+    needs: parseBotManifestNeeds(manifest),
     repository: `https://github.com/${owner}/${repo}`,
     homepage,
     github_repo_id: meta?.id,

--- a/apps/cursor/src/lib/bots/parse.ts
+++ b/apps/cursor/src/lib/bots/parse.ts
@@ -1,0 +1,253 @@
+/**
+ * Parse a public GitHub repo into a bot listing.
+ *
+ * Do not call parseGitHubPlugin here. That parser requires Open Plugins
+ * files and maps `agents/*.md` to plugin components. A bot listing is a
+ * use-case template (`bot.json` / `BOT.md`). Reuse would reject a valid bot
+ * repo (`no_components`) and would ingest agent files as this listing's body.
+ */
+
+import {
+  type FetchOptions,
+  fetchGitHubRepoMeta,
+  fetchWithRateLimit,
+  githubAuthHeaders,
+  parseGitHubUrl,
+} from "@/lib/github-plugin/parse";
+import { slugify } from "@/lib/slug";
+import { type BotNeed, botNeedSchema } from "./types";
+
+export type ParsedBot = {
+  name: string;
+  description: string;
+  writeup: string;
+  template: string;
+  needs: BotNeed[];
+  repository: string;
+  homepage?: string;
+  github_repo_id?: number;
+};
+
+export class BotParseError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | "invalid_url"
+      | "repo_unreadable"
+      | "no_bot"
+      | "open_plugin_agent",
+  ) {
+    super(message);
+    this.name = "BotParseError";
+  }
+}
+
+const MANIFEST_PATHS = ["bot.json", ".cursor/bot.json"];
+const TEMPLATE_PATHS = ["BOT.md", "bot.md", "template.md"];
+const WRITEUP_PATHS = ["WRITEUP.md", "writeup.md", "README.md"];
+
+async function fetchGitHubFile(
+  owner: string,
+  repo: string,
+  path: string,
+): Promise<string | null> {
+  const url = `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${path}`;
+  try {
+    const res = await fetch(url, { cache: "no-store" });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchGitHubTree(
+  owner: string,
+  repo: string,
+  opts: FetchOptions = {},
+): Promise<{ path: string; type: string }[]> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/HEAD?recursive=1`;
+  try {
+    const res = await fetchWithRateLimit(url, {
+      cache: "no-store",
+      headers: {
+        Accept: "application/vnd.github.v3+json",
+        ...githubAuthHeaders(),
+      },
+      maxWaitMs: opts.maxWaitMs,
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.tree ?? []).map((t: { path: string; type: string }) => ({
+      path: t.path,
+      type: t.type,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function parseNeeds(manifest: Record<string, unknown>): BotNeed[] {
+  const needs: BotNeed[] = [];
+
+  const plugins = manifest.plugins;
+  if (Array.isArray(plugins)) {
+    for (const entry of plugins) {
+      if (typeof entry === "string" && entry.trim()) {
+        const name = entry.trim();
+        needs.push({ kind: "plugin", name, slug: slugify(name) });
+        continue;
+      }
+      const rec = asRecord(entry);
+      if (!rec) continue;
+      const name = typeof rec.name === "string" ? rec.name.trim() : "";
+      if (!name) continue;
+      const parsed = botNeedSchema.safeParse({
+        kind: "plugin",
+        name,
+        ...(typeof rec.slug === "string" && rec.slug.trim()
+          ? { slug: rec.slug.trim() }
+          : { slug: slugify(name) }),
+        ...(typeof rec.repository === "string" && rec.repository.trim()
+          ? { repository: rec.repository.trim() }
+          : {}),
+      });
+      if (parsed.success) needs.push(parsed.data);
+    }
+  }
+
+  const skills = manifest.skills;
+  if (Array.isArray(skills)) {
+    for (const entry of skills) {
+      if (typeof entry === "string" && entry.trim()) {
+        needs.push({ kind: "skill", name: entry.trim() });
+        continue;
+      }
+      const rec = asRecord(entry);
+      if (!rec) continue;
+      const name = typeof rec.name === "string" ? rec.name.trim() : "";
+      if (!name) continue;
+      needs.push({ kind: "skill", name });
+    }
+  }
+
+  return needs;
+}
+
+function hasOpenPluginAgents(tree: { path: string; type: string }[]): boolean {
+  return tree.some(
+    (f) => f.type === "blob" && /(^|\/)agents\/[^/]+\.md$/.test(f.path),
+  );
+}
+
+export async function parseGitHubBot(
+  url: string,
+  options: { maxWaitMs?: number } = {},
+): Promise<ParsedBot> {
+  const parsed = parseGitHubUrl(url);
+  if (!parsed) {
+    throw new BotParseError(
+      "Invalid GitHub URL. Expected format: https://github.com/owner/repo",
+      "invalid_url",
+    );
+  }
+
+  const { owner, repo } = parsed;
+  const fetchOpts: FetchOptions = { maxWaitMs: options.maxWaitMs };
+
+  const tree = await fetchGitHubTree(owner, repo, fetchOpts);
+  if (tree.length === 0) {
+    throw new BotParseError(
+      "Could not read repository. Make sure the repo exists, is public, and the URL is correct.",
+      "repo_unreadable",
+    );
+  }
+
+  let manifest: Record<string, unknown> = {};
+  let foundManifest = false;
+  for (const path of MANIFEST_PATHS) {
+    const content = await fetchGitHubFile(owner, repo, path);
+    if (!content) continue;
+    try {
+      const json: unknown = JSON.parse(content);
+      const rec = asRecord(json);
+      if (rec) {
+        manifest = rec;
+        foundManifest = true;
+        break;
+      }
+    } catch {
+      throw new BotParseError(`Could not parse ${path} as JSON.`, "no_bot");
+    }
+  }
+
+  let template =
+    typeof manifest.template === "string" ? manifest.template.trim() : "";
+  if (!template) {
+    for (const path of TEMPLATE_PATHS) {
+      const content = await fetchGitHubFile(owner, repo, path);
+      if (content?.trim()) {
+        template = content.trim();
+        break;
+      }
+    }
+  }
+
+  let writeup =
+    typeof manifest.writeup === "string" ? manifest.writeup.trim() : "";
+  if (!writeup) {
+    for (const path of WRITEUP_PATHS) {
+      const content = await fetchGitHubFile(owner, repo, path);
+      if (content?.trim()) {
+        writeup = content.trim();
+        break;
+      }
+    }
+  }
+
+  const name =
+    (typeof manifest.name === "string" && manifest.name.trim()) ||
+    repo.replace(/[-_]+/g, " ");
+  const description =
+    (typeof manifest.description === "string" && manifest.description.trim()) ||
+    writeup.slice(0, 180) ||
+    template.slice(0, 180);
+
+  if (!template || !writeup) {
+    if (!foundManifest && hasOpenPluginAgents(tree)) {
+      throw new BotParseError(
+        "This repo looks like an Open Plugins agent (`agents/*.md`). That is a plugin component, not a bot listing. Submit it at /plugins/new. A bot repo needs bot.json or BOT.md plus a use-case writeup.",
+        "open_plugin_agent",
+      );
+    }
+    throw new BotParseError(
+      "No bot listing found. Add bot.json (name, description, template, writeup, plugins, skills) or BOT.md plus a README/WRITEUP.md. Open Plugins `agents/*.md` files are plugins, not bots.",
+      "no_bot",
+    );
+  }
+
+  const homepage =
+    typeof manifest.homepage === "string" && manifest.homepage.trim()
+      ? manifest.homepage.trim()
+      : undefined;
+
+  const meta = await fetchGitHubRepoMeta(owner, repo, fetchOpts);
+
+  return {
+    name,
+    description: description.slice(0, 280),
+    writeup,
+    template,
+    needs: parseNeeds(manifest),
+    repository: `https://github.com/${owner}/${repo}`,
+    homepage,
+    github_repo_id: meta?.id,
+  };
+}

--- a/apps/cursor/src/lib/bots/seed.ts
+++ b/apps/cursor/src/lib/bots/seed.ts
@@ -1,0 +1,72 @@
+import type { BotRow } from "./types";
+
+/**
+ * Editorial use-case used when `public.bots` is not in the connected
+ * database yet (preview/prod before `20260824_bots.sql`). Keep in sync
+ * with the insert in that migration. Queries prefer the table when it exists.
+ */
+export const SEED_BOT_SLUG = "review-a-pull-request";
+
+export const SEED_BOT: BotRow = {
+  id: "00000000-0000-4000-8000-000000000001",
+  name: "Review a pull request",
+  slug: SEED_BOT_SLUG,
+  description:
+    "Paste this template into Cursor, install the plugins it lists, and review a GitHub pull request from the agent chat.",
+  writeup: `Review a pull request from Cursor without leaving the editor.
+
+This page is a use-case listing, not a plugin. It ships a copyable bot template, the plugins and skills that template expects, and the steps to run it. Search engines should rank this URL for the job (review a PR in Cursor), not for a plugin name.
+
+A bot listing is not an Open Plugins agent file. \`agents/*.md\` in a repo is a plugin component. Submit that repo at /plugins/new. Submit a bot when the repo describes a use case: a template someone can copy, plus the plugins or skills it needs.
+
+How it works
+
+Copy the template on this page. Paste it into Cursor agent chat. Install any listed plugins you do not already have. Then give the agent the pull request URL or the local branch.
+
+What to ask the agent
+
+Name the files that changed. Ask it to check tests, error handling, and secrets. Ask it to say what it would not merge, and why.`,
+  template: `You are reviewing a GitHub pull request in this repo.
+
+1. Identify the PR (URL, branch, or \`gh pr view\` output I paste).
+2. Summarize the change in three sentences or fewer.
+3. List the files that matter and what each one does in this diff.
+4. Call out bugs, missing tests, secret leaks, and API contract breaks.
+5. Say whether you would merge, request changes, or reject. Give one reason.
+
+Do not invent files that are not in the diff. If you cannot see the PR, ask me for the URL.`,
+  needs: [
+    { kind: "plugin", name: "GitHub", slug: "github" },
+    { kind: "skill", name: "code-review" },
+  ],
+  repository: "https://github.com/cursor/community-plugins",
+  homepage: null,
+  logo: null,
+  owner_id: null,
+  active: true,
+  scan_status: "unscanned",
+  discovery_source: "seed:cursor-directory",
+  github_repo_id: null,
+  created_at: "2026-08-24T00:00:00.000Z",
+  updated_at: "2026-08-24T00:00:00.000Z",
+};
+
+export function isMissingRelationError(
+  error: unknown,
+  relation: string,
+): boolean {
+  const code =
+    typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code: unknown }).code)
+      : "";
+  const message =
+    typeof error === "object" && error !== null && "message" in error
+      ? String((error as { message: unknown }).message)
+      : String(error ?? "");
+  return (
+    code === "PGRST205" ||
+    code === "42P01" ||
+    message.includes(`public.${relation}`) ||
+    message.includes(`relation "${relation}"`)
+  );
+}

--- a/apps/cursor/src/lib/bots/seed.ts
+++ b/apps/cursor/src/lib/bots/seed.ts
@@ -68,6 +68,6 @@ export function isMissingRelationError(
     code === "42P01" ||
     message.includes(`public.${relation}`) ||
     message.includes(`relation "${relation}"`) ||
-    message.includes("schema cache")
+    (message.includes("schema cache") && message.includes(relation))
   );
 }

--- a/apps/cursor/src/lib/bots/seed.ts
+++ b/apps/cursor/src/lib/bots/seed.ts
@@ -67,6 +67,7 @@ export function isMissingRelationError(
     code === "PGRST205" ||
     code === "42P01" ||
     message.includes(`public.${relation}`) ||
-    message.includes(`relation "${relation}"`)
+    message.includes(`relation "${relation}"`) ||
+    message.includes("schema cache")
   );
 }

--- a/apps/cursor/src/lib/bots/types.ts
+++ b/apps/cursor/src/lib/bots/types.ts
@@ -1,0 +1,79 @@
+/**
+ * Bot listing domain types. A bot is a use-case page: copyable template,
+ * plugins/skills it needs, SEO writeup. Not a plugin category and not an
+ * Open Plugins `agents/*.md` component.
+ */
+
+import { z } from "zod";
+import type { ScanStatus } from "@/lib/plugins/types";
+
+const SCAN_STATUSES: readonly ScanStatus[] = [
+  "pending",
+  "scanning",
+  "safe",
+  "flagged",
+  "error",
+  "unscanned",
+];
+
+export function parseScanStatus(value: unknown): ScanStatus {
+  for (const status of SCAN_STATUSES) {
+    if (value === status) return status;
+  }
+  return "pending";
+}
+
+export const botNeedSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("plugin"),
+    name: z.string().min(1),
+    slug: z.string().min(1).optional(),
+    repository: z.string().url().optional(),
+  }),
+  z.object({
+    kind: z.literal("skill"),
+    name: z.string().min(1),
+  }),
+]);
+
+export type BotNeed = z.infer<typeof botNeedSchema>;
+
+export const botNeedsSchema = z.array(botNeedSchema);
+
+export type ResolvedBotNeed =
+  | (Extract<BotNeed, { kind: "plugin" }> & { href: string | null })
+  | Extract<BotNeed, { kind: "skill" }>;
+
+export type BotRow = {
+  id: string;
+  name: string;
+  slug: string;
+  description: string;
+  writeup: string;
+  template: string;
+  needs: BotNeed[];
+  repository: string | null;
+  homepage: string | null;
+  logo: string | null;
+  owner_id: string | null;
+  active: boolean;
+  scan_status: ScanStatus;
+  discovery_source: string | null;
+  github_repo_id: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type BotDetail = Omit<BotRow, "needs"> & {
+  needs: ResolvedBotNeed[];
+};
+
+export function parseBotNeeds(value: unknown): BotNeed[] {
+  if (!Array.isArray(value)) return [];
+  const needs: BotNeed[] = [];
+  for (const item of value) {
+    const parsed = botNeedSchema.safeParse(item);
+    if (parsed.success) needs.push(parsed.data);
+  }
+  return needs;
+}

--- a/apps/cursor/src/lib/bots/types.ts
+++ b/apps/cursor/src/lib/bots/types.ts
@@ -1,9 +1,3 @@
-/**
- * Bot listing domain types. A bot is a use-case page: copyable template,
- * plugins/skills it needs, SEO writeup. Not a plugin category and not an
- * Open Plugins `agents/*.md` component.
- */
-
 import { z } from "zod";
 import type { ScanStatus } from "@/lib/plugins/types";
 

--- a/supabase/migrations/20260824_bots.sql
+++ b/supabase/migrations/20260824_bots.sql
@@ -88,6 +88,10 @@ end$$;
 
 alter table public.bots enable row level security;
 
+-- Active listings are world-readable; owners can read and delete their own
+-- rows. Inserts and updates go through the service-role admin client
+-- (createBotAction / reviewBotAction). Authenticated clients have no insert
+-- or update policy, so they cannot self-publish by writing active = true.
 do $$
 begin
   if not exists (
@@ -97,27 +101,6 @@ begin
   ) then
     create policy bots_select_active_or_own on public.bots
       for select using (active = true or (select auth.uid()) = owner_id);
-  end if;
-
-  if not exists (
-    select 1 from pg_policies
-    where schemaname = 'public' and tablename = 'bots'
-      and policyname = 'bots_insert_own'
-  ) then
-    create policy bots_insert_own on public.bots
-      for insert to authenticated
-      with check ((select auth.uid()) = owner_id);
-  end if;
-
-  if not exists (
-    select 1 from pg_policies
-    where schemaname = 'public' and tablename = 'bots'
-      and policyname = 'bots_update_own'
-  ) then
-    create policy bots_update_own on public.bots
-      for update to authenticated
-      using ((select auth.uid()) = owner_id)
-      with check ((select auth.uid()) = owner_id);
   end if;
 
   if not exists (

--- a/supabase/migrations/20260824_bots.sql
+++ b/supabase/migrations/20260824_bots.sql
@@ -1,0 +1,190 @@
+-- First-class bot listings (use-case pages), sibling to plugins / mcps.
+-- A bot is a copyable template + the plugins/skills it needs + a writeup.
+-- It is not an Open Plugins `agents/*.md` component.
+
+create table if not exists public.bots (
+  id uuid primary key default gen_random_uuid(),
+  name text not null unique,
+  slug text not null unique,
+  description text not null,
+  writeup text not null,
+  template text not null,
+  needs jsonb not null default '[]'::jsonb,
+  repository text,
+  homepage text,
+  logo text,
+  owner_id uuid references public.users (id) on delete set null,
+  active boolean not null default false,
+  scan_status text not null default 'pending'
+    check (scan_status in (
+      'pending',
+      'scanning',
+      'safe',
+      'flagged',
+      'error',
+      'unscanned'
+    )),
+  discovery_source text,
+  github_repo_id bigint,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint bots_needs_is_array check (jsonb_typeof(needs) = 'array')
+);
+
+create unique index if not exists bots_github_repo_id_unique
+  on public.bots (github_repo_id)
+  where github_repo_id is not null;
+
+create index if not exists bots_active_created_at_idx
+  on public.bots (created_at desc)
+  where active = true;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'generate_bot_slug'
+  ) then
+    create function public.generate_bot_slug()
+    returns trigger
+    language plpgsql
+    set search_path = public
+    as $fn$
+    declare
+      v_slug text;
+    begin
+      if new.slug is not null and new.slug <> '' then
+        return new;
+      end if;
+      v_slug := btrim(regexp_replace(lower(new.name), '[^a-z0-9]+', '-', 'g'), '-');
+      if v_slug is null or v_slug = '' then
+        v_slug := 'bot';
+      end if;
+      v_slug := left(v_slug, 80);
+      if exists (select 1 from public.bots b where b.slug = v_slug) then
+        v_slug := left(v_slug, 73) || '-' || substr(md5(random()::text), 1, 6);
+      end if;
+      new.slug := v_slug;
+      return new;
+    end;
+    $fn$;
+  end if;
+
+  if not exists (select 1 from pg_trigger where tgname = 'bots_generate_slug') then
+    create trigger bots_generate_slug
+      before insert on public.bots
+      for each row execute function public.generate_bot_slug();
+  end if;
+
+  if exists (
+    select 1 from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'set_updated_at'
+  ) and not exists (
+    select 1 from pg_trigger where tgname = 'bots_set_updated_at'
+  ) then
+    create trigger bots_set_updated_at
+      before update on public.bots
+      for each row execute function public.set_updated_at();
+  end if;
+end$$;
+
+alter table public.bots enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'bots'
+      and policyname = 'bots_select_active_or_own'
+  ) then
+    create policy bots_select_active_or_own on public.bots
+      for select using (active = true or (select auth.uid()) = owner_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'bots'
+      and policyname = 'bots_insert_own'
+  ) then
+    create policy bots_insert_own on public.bots
+      for insert to authenticated
+      with check ((select auth.uid()) = owner_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'bots'
+      and policyname = 'bots_update_own'
+  ) then
+    create policy bots_update_own on public.bots
+      for update to authenticated
+      using ((select auth.uid()) = owner_id)
+      with check ((select auth.uid()) = owner_id);
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public' and tablename = 'bots'
+      and policyname = 'bots_delete_own'
+  ) then
+    create policy bots_delete_own on public.bots
+      for delete to authenticated using ((select auth.uid()) = owner_id);
+  end if;
+end$$;
+
+-- Editorial seed so /bots and generateStaticParams have one use-case page
+-- on an empty database. Idempotent on slug.
+insert into public.bots (
+  name,
+  slug,
+  description,
+  writeup,
+  template,
+  needs,
+  repository,
+  active,
+  scan_status,
+  discovery_source
+)
+values (
+  'Review a pull request',
+  'review-a-pull-request',
+  'Paste this template into Cursor, install the plugins it lists, and review a GitHub pull request from the agent chat.',
+  $writeup$
+Review a pull request from Cursor without leaving the editor.
+
+This page is a use-case listing, not a plugin. It ships a copyable bot template, the plugins and skills that template expects, and the steps to run it. Search engines should rank this URL for the job (review a PR in Cursor), not for a plugin name.
+
+A bot listing is not an Open Plugins agent file. `agents/*.md` in a repo is a plugin component. Submit that repo at /plugins/new. Submit a bot when the repo describes a use case: a template someone can copy, plus the plugins or skills it needs.
+
+How it works
+
+Copy the template on this page. Paste it into Cursor agent chat. Install any listed plugins you do not already have. Then give the agent the pull request URL or the local branch.
+
+What to ask the agent
+
+Name the files that changed. Ask it to check tests, error handling, and secrets. Ask it to say what it would not merge, and why.
+$writeup$,
+  $template$
+You are reviewing a GitHub pull request in this repo.
+
+1. Identify the PR (URL, branch, or `gh pr view` output I paste).
+2. Summarize the change in three sentences or fewer.
+3. List the files that matter and what each one does in this diff.
+4. Call out bugs, missing tests, secret leaks, and API contract breaks.
+5. Say whether you would merge, request changes, or reject. Give one reason.
+
+Do not invent files that are not in the diff. If you cannot see the PR, ask me for the URL.
+$template$,
+  '[
+    {"kind":"plugin","name":"GitHub","slug":"github"},
+    {"kind":"skill","name":"code-review"}
+  ]'::jsonb,
+  'https://github.com/cursor/community-plugins',
+  true,
+  'unscanned',
+  'seed:cursor-directory'
+)
+on conflict (slug) do nothing;

--- a/supabase/migrations/20260824_bots.sql
+++ b/supabase/migrations/20260824_bots.sql
@@ -1,7 +1,3 @@
--- First-class bot listings (use-case pages), sibling to plugins / mcps.
--- A bot is a copyable template + the plugins/skills it needs + a writeup.
--- It is not an Open Plugins `agents/*.md` component.
-
 create table if not exists public.bots (
   id uuid primary key default gen_random_uuid(),
   name text not null unique,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

cursor.directory needs a listing type for copyable bot templates that compose plugins and skills into one searchable use-case page. That is not a plugin category. Open Plugins `agents/*.md` files stay plugin components.

This site already hosts sibling routes (`/plugins`, `/members`) and sibling tables (`plugins`, `mcps`). `/bots` fits here. A separate bot.directory is not required.

## Scope

- New `public.bots` table, RLS, slug trigger, and one seeded row (`review-a-pull-request`) in `supabase/migrations/20260824_bots.sql`.
- Domain module `apps/cursor/src/lib/bots/` (`types`, `parseGitHubBot`, `insertBot`, editorial `seed` fallback). Parser reads `bot.json` / `BOT.md` / writeup files. It does not call `parseGitHubPlugin`. A repo that only has `agents/*.md` is rejected with a pointer to `/plugins/new`.
- Submit: `/bots/new` (GitHub or Google sign-in), `createBotAction`, pending `scan_status` without enqueueing `plugin_scans`.
- Review: `/admin/bots` approve/decline, same shape as plugin hidden-queue actions.
- Public: `/bots` list, `/bots/[slug]` detail (template, copy path, plugin/skill needs, writeup), sitemap + Bots nav.
- README: how to submit a bot vs a plugin.
- If `public.bots` is missing (preview/prod before `20260824_bots.sql`), reads fall back to the editorial seed so Cache Components can prerender `/bots/review-a-pull-request`. Transient query failures are not cached as that seed. No production schema grant is required for this PR.
- Writes go through the service-role admin client. RLS allows select of active/own rows and owner delete. There is no insert or update policy, so an authenticated user cannot self-publish by setting `active = true`.
- Parser keeps a plugin need when `repository` is present but not a URL (drops only that field). Invalid `bot.json` does not abort; it tries `.cursor/bot.json` and markdown fallbacks.

Out of scope: plugin security scan for bots, Slack bots, a new Anysphere repo, changing plugin submit/scan/trending.

## Tradeoffs

We store needs as jsonb parsed into a `kind` union, not a join table. The detail page still links `/plugins/{slug}` when that plugin exists. An empty plugins table does not 500.

Bot scan is stubbed. User submit inserts `active=false`. We do not put bot ids on `plugin_scans`, because drain calls `runPluginScan` and would regress plugins.

The seed listing exists twice until the migration is applied: SQL for databases that have the table, TypeScript for builds that do not. Queries prefer the table when it exists.

## Blast Radius

Public nav gains a Bots link. Plugin homepage trending, `createPluginAction`, `parseGitHubPlugin`, and the scan drain path are untouched.

The migration inserts one editorial bot. Applying it in production publishes that seed.

## Verification

- `bun run typecheck` in `apps/cursor` (pass).
- `bunx biome ci .` (pass, pre-existing `<img>` warnings only).
- GitHub Actions "Lint & typecheck" green. Vercel preview green on `82e74d2`.
- Parser: invalid plugin `repository` keeps `name`/`slug`. Invalid `bot.json` falls through to `.cursor/bot.json` or `BOT.md`.
- RLS: owner insert of `active=true` is `42501`. Owner patch of `active=true` updates 0 rows. Service-role insert succeeds.
- Local Postgres + PostgREST: `/bots` and `/bots/review-a-pull-request` 200. `/bots/new` redirects to login.

Do not merge until review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea441713-bf07-469a-a7c0-21ea98960136?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea441713-bf07-469a-a7c0-21ea98960136&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

